### PR TITLE
Fix file loading

### DIFF
--- a/lib/jekyll-graphviz.rb
+++ b/lib/jekyll-graphviz.rb
@@ -1,0 +1,1 @@
+require 'jekyll/graphviz'


### PR DESCRIPTION
Jekyll isn't picking up on the liquid template definitions since it isn't loading `jekyll/graphviz`.  Adding this file corrects the error.
